### PR TITLE
Revert "chore(deps): update dependency urllib3 to v2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ six==1.16.0
 timeout-decorator==0.5.0
 tzdata==2023.3
 tzlocal==4.3
-urllib3==2.0.1
+urllib3==1.26.15
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 Werkzeug==2.3.2


### PR DESCRIPTION
Reverts yteraoka/cwlui#33

```
#8 5.156 The conflict is caused by:
#8 5.156     The user requested urllib3==2.0.1
#8 5.156     botocore 1.29.123 depends on urllib3<1.27 and >=1.25.4
```